### PR TITLE
Use box_url to fix vagrant warning

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,7 +3,8 @@
 
 Vagrant.configure(2) do |config|
   # Swift development targets Ubuntu 15.10
-  config.vm.box = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
+  config.vm.box = "ubuntu/trusty64"
+  config.vm.box_url = "https://cloud-images.ubuntu.com/vagrant/trusty/current/trusty-server-cloudimg-amd64-vagrant-disk1.box"
   config.vm.define "swift-dev" do |swiftdev|
   end
 


### PR DESCRIPTION
When running vagrant up the following warning was shown:
"==> swift-dev: It looks like you attempted to add a box with a URL for the name...
 ==> swift-dev: Instead, use box_url instead of box for box URLs."